### PR TITLE
적 공격시 방어구 스탯 적용 고침

### DIFF
--- a/CH2Project/BossMonster.cpp
+++ b/CH2Project/BossMonster.cpp
@@ -25,6 +25,7 @@ void BossMonster::AttackPlayer(Characters& player)
     int prevPlayerHealth = player.GetHealth();
     bool IsSkill = false; //스킬 사용 여부
     int newHealth = 0;
+    int ArmorSubAttack = 0;
 
     //30% 확률로 스킬 공격
     int skillChance = chanceDistribution(rng);
@@ -32,12 +33,24 @@ void BossMonster::AttackPlayer(Characters& player)
     {
         cout << Name << "이(가) 강력한 기술로 " << player.GetName() << "를 공격합니다! ";
         IsSkill = true;
-        newHealth = prevPlayerHealth - SkillAttack + player.GetTotalArmorStat();
+        if (player.GetTotalArmorStat() - SkillAttack > 0) {
+            ArmorSubAttack = 0;
+        }
+        else {
+            ArmorSubAttack = player.GetTotalArmorStat() - SkillAttack;
+        }
+        newHealth = prevPlayerHealth + ArmorSubAttack;
     }
     else
     {
         cout << Name << "이(가) " << player.GetName() << "를 공격합니다! ";
-        newHealth = prevPlayerHealth - Attack + player.GetTotalArmorStat();
+        if (player.GetTotalArmorStat() - Attack > 0) {
+            ArmorSubAttack = 0;
+        }
+        else {
+            ArmorSubAttack = player.GetTotalArmorStat() - Attack;
+        }
+        newHealth = prevPlayerHealth + ArmorSubAttack;
     }
 
     if (newHealth < 0)

--- a/CH2Project/GoldenGoblin.cpp
+++ b/CH2Project/GoldenGoblin.cpp
@@ -38,7 +38,14 @@ void GoldenGoblin::OnDeath(Characters& player)
 void GoldenGoblin::AttackPlayer(Characters& player) 
 {
 	int prevPlayerHealth = player.GetHealth();
-	int newHealth = prevPlayerHealth - Attack + player.GetTotalArmorStat();
+	int ArmorSubAttack = 0;
+	if (player.GetTotalArmorStat() - Attack > 0) {
+		ArmorSubAttack = 0;
+	}
+	else {
+		ArmorSubAttack = player.GetTotalArmorStat() - Attack;
+	}
+	int newHealth = prevPlayerHealth + ArmorSubAttack;
 	int prevGold = player.GetGold();
 	if (prevGold > 0) 
 	{

--- a/CH2Project/Monster.cpp
+++ b/CH2Project/Monster.cpp
@@ -65,7 +65,14 @@ int Monster::DropItem()
 
 void Monster::AttackPlayer(Characters& player) {
     int prevPlayerHealth = player.GetHealth();
-    int newHealth = prevPlayerHealth - Attack + player.GetTotalArmorStat();
+    int ArmorSubAttack = 0;
+    if (player.GetTotalArmorStat() - Attack > 0) {
+        ArmorSubAttack = 0;
+    }
+    else {
+        ArmorSubAttack = player.GetTotalArmorStat() - Attack;
+    }
+    int newHealth = prevPlayerHealth + ArmorSubAttack;
 
     if (newHealth < 0) { newHealth = 0; }
     player.SetHealth(newHealth);


### PR DESCRIPTION
방어구 스탯이 적 공격력보다 높으면 체력이 올라가는거 방지